### PR TITLE
fix:allow workshop 3.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 ovos-utils>=0.0.38,<2.0.0
-ovos-workshop>=2.4.0,<3.0.0
+ovos-workshop>=2.4.0,<4.0.0
 ovos-date-parser>=0.0.3,<1.0.0
 ovos-bus-client>=1.0.0,<2.0.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated version constraint for the `ovos-workshop` package to allow compatibility with versions up to 4.0.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->